### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This server provides cloud browser automation capabilities using [Browserbase](h
 
 To learn to get started with Browserbase, check out ['browserbase/README.md'](./browserbase/README.md) or [Stagehand MCP](./stagehand/README.md).
 
+<a href="https://glama.ai/mcp/servers/0kznte4aoh"><img width="380" height="200" src="https://glama.ai/mcp/servers/0kznte4aoh/badge" alt="mcp-server-browserbase MCP server" /></a>
+
 ## Getting Started with available MCPs
 
 🌐 **Browserbase MCP** - Located in [`browserbase/`](./browserbase/)


### PR DESCRIPTION
This PR adds a badge for the mcp-server-browserbase server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/0kznte4aoh"><img width="380" height="200" src="https://glama.ai/mcp/servers/0kznte4aoh/badge" alt="mcp-server-browserbase MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.