### PR TITLE
Fix stagehand_extract data unwrapping

### DIFF
--- a/stagehand/src/index.ts
+++ b/stagehand/src/index.ts
@@ -289,12 +289,16 @@ async function handleToolCall(
           instruction: args.instruction,
           schema: zodSchema,
         });
-        log(`Data extracted successfully: ${JSON.stringify(data)}`);
+        if (!data || typeof data !== "object" || !("data" in data)) {
+          throw new Error("Invalid extraction response format");
+        }
+        const extractedData = data.data;
+        log(`Data extracted successfully: ${JSON.stringify(extractedData)}`);
         return {
           content: [
             {
               type: "text",
-              text: `Extraction result: ${JSON.stringify(data)}`,
+              text: `Extraction result: ${JSON.stringify(extractedData)}`,
             },
             {
               type: "text",


### PR DESCRIPTION
When running as a local server/local client following the MCP documentation, the stagehand_extract data isn't properly unwrapped before returning to the client.