### PR TITLE
add session url to navigate tool response

### DIFF
--- a/stagehand/src/index.ts
+++ b/stagehand/src/index.ts
@@ -259,6 +259,10 @@ async function handleToolCall(
               type: "text",
               text: `Navigated to: ${args.url}`,
             },
+            {
+              type: "text",
+              text: `View the live session here: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`,
+            },
           ],
           isError: false,
         };


### PR DESCRIPTION
- adds the session url to the navigate tool response. This makes it easier for people to view their session live if they want to for whatever reason 