### PR TITLE
Fix: Ensure await stagehand.init() is called before referencing page object (Closes #56)

### DIFF
--- a/stagehand/src/server.ts
+++ b/stagehand/src/server.ts
@@ -92,6 +92,7 @@ export async function ensureStagehand() {
 
     // Try to perform a simple operation to check if the session is still valid
     try {
+      await stagehand.init();
       await stagehand.page.evaluate(() => document.title);
       return stagehand;
     } catch (error) {


### PR DESCRIPTION
This PR fixes an initialization error with Stagehand MCP when using a local Chrome instance (CDP on port 9222).

- Ensures that `await stagehand.init()` is called before any reference to the `page` object.
- - Prevents errors such as:
-   - `Cannot create proxy with a non-object as target or handler.`
-   - `You seem to be calling page on a page in an uninitialized Stagehand object. Ensure you are running await stagehand.init() on the Stagehand object before referencing the page object.`
Closes #56.

Thank you for reviewing!