### PR TITLE
[FIX]: fix node 19.9 issues

### DIFF
--- a/browserbase/src/program.ts
+++ b/browserbase/src/program.ts
@@ -7,11 +7,9 @@ import { startHttpTransport, startStdioTransport } from './transport.js';
 
 import { resolveConfig } from './config.js';
 
-import packageJSON from '../package.json' with { type: 'json' };
-
 program
-    .version('Version ' + packageJSON.version)
-    .name(packageJSON.name)
+    .version('1.0.5')
+    .name('Browserbase MCP Server')
     .option('--browserbaseApiKey <key>', 'The Browserbase API Key to use')
     .option('--browserbaseProjectId <id>', 'The Browserbase Project ID to use')
     .option('--proxies', 'Use Browserbase proxies.')


### PR DESCRIPTION
# What 

Getting the version from the Package.json file was causing issues with people using older versions of node. 

Setting it manually now to fix issues. 
