### PR TITLE
Added stagehand_get_html tool to Stagehand MCP Server

### DIFF
--- a/stagehand/package.json
+++ b/stagehand/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",
+    "dev": "npm run build && STAGEHAND_HTTP_PORT=8081 node dist/index.js",
     "prepare": "npm run build",
     "watch": "tsc --watch"
   },

--- a/stagehand/src/httpStaticServer.ts
+++ b/stagehand/src/httpStaticServer.ts
@@ -1,0 +1,94 @@
+import http from "http";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Function to clean the tmp directory
+function cleanTmpDirectory(directory: string) {
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true });
+    return;
+  }
+
+  try {
+    const files = fs.readdirSync(directory);
+    for (const file of files) {
+      if (file.startsWith('.')) continue; // Skip hidden files
+      
+      const filePath = path.join(directory, file);
+      fs.unlinkSync(filePath);
+    }
+    console.log(`Cleaned tmp directory: ${directory}`);
+  } catch (err) {
+    console.error(`Error cleaning tmp directory: ${err}`);
+  }
+}
+
+export function startStaticHttpServer() {
+  const TMP_DIR = path.resolve(__dirname, "../tmp");
+  const HTTP_PORT = process.env.STAGEHAND_HTTP_PORT ? parseInt(process.env.STAGEHAND_HTTP_PORT, 10) : 8080;
+
+  // Clean the tmp directory on startup
+  cleanTmpDirectory(TMP_DIR);
+
+  const server = http.createServer((req, res) => {
+    if (!req.url) {
+      res.writeHead(400);
+      res.end("Bad Request");
+      return;
+    }
+    // Only allow /tmp/ URLs
+    if (!req.url.startsWith("/tmp/")) {
+      res.writeHead(404);
+      res.end("Not Found");
+      return;
+    }
+    // Directory listing for /tmp/ or /tmp
+    if (req.url === "/tmp/" || req.url === "/tmp") {
+      fs.readdir(TMP_DIR, (err, files) => {
+        if (err) {
+          res.writeHead(500);
+          res.end("Failed to read directory");
+          return;
+        }
+        const links = files
+          .filter(f => !f.startsWith("."))
+          .map(f => `<li><a href=\"/tmp/${encodeURIComponent(f)}\">${f}</a></li>`) // encode for safety
+          .join("\n");
+        const html = `<!DOCTYPE html><html><head><title>tmp Directory Listing</title></head><body><h1>Files in /tmp/</h1><ul>${links}</ul></body></html>`;
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(html);
+      });
+      return;
+    }
+    // Serve individual files
+    const filePath = path.join(TMP_DIR, req.url.replace("/tmp/", ""));
+    if (!filePath.startsWith(TMP_DIR)) {
+      res.writeHead(403);
+      res.end("Forbidden");
+      return;
+    }
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.writeHead(404);
+        res.end("Not Found");
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(data);
+    });
+  });
+  let actualPort = HTTP_PORT;
+  server.listen(HTTP_PORT, () => {
+    const address = server.address();
+    if (address && typeof address === 'object') {
+      actualPort = address.port;
+    }
+    // eslint-disable-next-line no-console
+    console.log(`Static file server running at http://localhost:${actualPort}/tmp/`);
+  });
+  return { server, port: actualPort };
+} 

--- a/stagehand/src/index.ts
+++ b/stagehand/src/index.ts
@@ -2,13 +2,22 @@
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
-import { ensureLogDirectory, registerExitHandlers, scheduleLogRotation, setupLogRotation } from "./logging.js";
+import {
+  ensureLogDirectory,
+  registerExitHandlers,
+  scheduleLogRotation,
+  setupLogRotation,
+} from "./logging.js";
+import { startStaticHttpServer } from "./httpStaticServer.js";
 
 // Run setup for logging
 ensureLogDirectory();
 setupLogRotation();
 scheduleLogRotation();
 registerExitHandlers();
+
+// Start the static HTTP server for /tmp and capture the port
+const { port: staticHttpPort } = startStaticHttpServer();
 
 // Run the server
 async function runServer() {
@@ -17,7 +26,7 @@ async function runServer() {
   await server.connect(transport);
   server.sendLoggingMessage({
     level: "info",
-    data: "Stagehand MCP server is ready to accept requests",
+    data: `Stagehand MCP server is ready to accept requests. Static HTTP server running on port ${staticHttpPort}`,
   });
 }
 


### PR DESCRIPTION
Added ability to get the HTML of the current page with a `stagehand_get_html` MCP tool.

Since the HTML is usually too big to send via the messaging protocol, the HTML file is saved locally to a `tmp` folder and a simple HTTP Server is spun up to serve the file (usually via CURL from the client).  The port defaults to 8080, but can be configured via the `STAGEHAND_HTTP_PORT` environment variable.