### PR TITLE
[STG-634] add user metadata into session create

### DIFF
--- a/src/stagehandStore.ts
+++ b/src/stagehandStore.ts
@@ -49,6 +49,9 @@ export const createStagehandInstance = async (
           : undefined,
         advancedStealth: config.advancedStealth ?? undefined,
       },
+      userMetadata: {
+        mcp: true,
+      },
     },
     logger: (logLine) => {
       console.error(`Stagehand[${sessionId}]: ${logLine.message}`);


### PR DESCRIPTION
# what

Adding user metadata into session create so we can track which stagehand sessions were created by MCP.