### PR TITLE
[GRO-187] adding keep alive flag to MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ The Browserbase MCP server accepts the following command-line flags:
 | -------------------------- | --------------------------------------------------------------------------- |
 | `--proxies`                | Enable Browserbase proxies for the session                                  |
 | `--advancedStealth`        | Enable Browserbase Advanced Stealth (Only for Scale Plan Users)             |
+| `--keepAlive`              | Enable Browserbase Keep Alive Session                                       |
 | `--contextId <contextId>`  | Specify a Browserbase Context ID to use                                     |
-| `--persist [boolean]`      | Whether to persist the Browserbase context (default: true)                  |
+| `--persist`                | Whether to persist the Browserbase context (default: true)                  |
 | `--port <port>`            | Port to listen on for HTTP/SHTTP transport                                  |
 | `--host <host>`            | Host to bind server to (default: localhost, use 0.0.0.0 for all interfaces) |
 | `--cookies [json]`         | JSON array of cookies to inject into the browser                            |

--- a/config.d.ts
+++ b/config.d.ts
@@ -24,6 +24,12 @@ export type Config = {
    */
   advancedStealth?: boolean;
   /**
+   * Whether or not to keep the Browserbase session alive
+   *
+   * @default false
+   */
+  keepAlive?: boolean;
+  /**
    * Potential Browserbase Context to use
    * Would be a context ID
    */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserbasehq/mcp-server-browserbase",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MCP server for AI web browser automation using Browserbase and Stagehand",
   "license": "Apache-2.0",
   "author": "Browserbase, Inc. (https://www.browserbase.com/)",

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,10 @@ export const configSchema = z
       .describe(
         "Use advanced stealth mode. Only available to Browserbase Scale Plan users",
       ),
+    keepAlive: z
+      .boolean()
+      .optional()
+      .describe("Whether or not to keep the Browserbase session alive"),
     context: z
       .object({
         contextId: z

--- a/src/stagehandStore.ts
+++ b/src/stagehandStore.ts
@@ -36,6 +36,7 @@ export const createStagehandInstance = async (
     browserbaseSessionCreateParams: {
       projectId,
       proxies: config.proxies,
+      keepAlive: config.keepAlive ?? false,
       browserSettings: {
         viewport: {
           width: config.viewPort?.browserWidth ?? 1024,


### PR DESCRIPTION
# what

Adding a flag to have keep alive sessions using the MCP server. If you want to close this kind of session,  you have to explicit close with the session close tool. 