### PR TITLE
Fix gemini CLI extension

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -2,10 +2,9 @@
   "name": "mcp-server-browserbase",
   "version": "2.4.1",
   "mcpServers": {
-    "browserbase": {
-      "command": "node",
-      "args": ["${extensionPath}${/}cli.js"],
-      "cwd": "${extensionPath}"
+    "mcp-server-browserbase": {
+      "command": "npx",
+      "args": ["@browserbasehq/mcp-server-browserbase"]
     }
   }
 }


### PR DESCRIPTION
- Swapped to a `npx`-based installation for the Gemini CLI extension MCP installation
- Renamed MCP to match convention (`mcp-server-browserbase`)