### PR TITLE
fix: await MCP notification in screenshot tool

### DIFF
--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -100,7 +100,6 @@ async function handleScreenshot(
       registerScreenshot(sessionId, name, screenshotBase64);
 
       // Notify the client that the resources changed
-      // Must await to ensure proper message ordering on the transport
       const serverInstance = context.getServer();
 
       if (serverInstance) {


### PR DESCRIPTION
Fix unawaited `notification()` call that could cause message ordering issues on the transport. The notification and tool response were potentially being written concurrently to stdout