### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,9 @@ export default function ({ config }: { config: z.infer<typeof configSchema> }) {
             );
           }
         },
+        {
+          annotations: tool.schema.annotations,
+        },
       );
     } else {
       console.warn(

--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -31,6 +31,10 @@ const actSchema: ToolSchema<typeof ActInputSchema> = {
   name: "browserbase_stagehand_act",
   description: `Perform a single action on the page (e.g., click, type).`,
   inputSchema: ActInputSchema,
+  annotations: {
+    title: "Perform Action",
+    destructiveHint: true,
+  },
 };
 
 async function handleAct(

--- a/src/tools/agent.ts
+++ b/src/tools/agent.ts
@@ -26,6 +26,10 @@ const agentSchema: ToolSchema<typeof AgentInputSchema> = {
   name: "browserbase_stagehand_agent",
   description: `Execute a task autonomously using Gemini Computer Use agent. The agent will navigate and interact with web pages to complete the given task.`,
   inputSchema: AgentInputSchema,
+  annotations: {
+    title: "Execute Agent Task",
+    destructiveHint: true,
+  },
 };
 
 async function handleAgent(

--- a/src/tools/extract.ts
+++ b/src/tools/extract.ts
@@ -27,6 +27,10 @@ const extractSchema: ToolSchema<typeof ExtractInputSchema> = {
   name: "browserbase_stagehand_extract",
   description: `Extract structured data or text from the current page using an instruction.`,
   inputSchema: ExtractInputSchema,
+  annotations: {
+    title: "Extract Data",
+    readOnlyHint: true,
+  },
 };
 
 async function handleExtract(

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -11,9 +11,13 @@ type NavigateInput = z.infer<typeof NavigateInputSchema>;
 
 const navigateSchema: ToolSchema<typeof NavigateInputSchema> = {
   name: "browserbase_stagehand_navigate",
-  description: `Navigate to a URL in the browser. Only use this tool with URLs you're confident will work and be up to date. 
+  description: `Navigate to a URL in the browser. Only use this tool with URLs you're confident will work and be up to date.
     Otherwise, use https://google.com as the starting point`,
   inputSchema: NavigateInputSchema,
+  annotations: {
+    title: "Navigate to URL",
+    destructiveHint: true,
+  },
 };
 
 async function handleNavigate(

--- a/src/tools/observe.ts
+++ b/src/tools/observe.ts
@@ -30,6 +30,10 @@ const observeSchema: ToolSchema<typeof ObserveInputSchema> = {
   name: "browserbase_stagehand_observe",
   description: `Find interactive elements on the page from an instruction; optionally return an action.`,
   inputSchema: ObserveInputSchema,
+  annotations: {
+    title: "Observe Elements",
+    readOnlyHint: true,
+  },
 };
 
 async function handleObserve(

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -21,6 +21,10 @@ const screenshotSchema: ToolSchema<typeof ScreenshotInputSchema> = {
   name: "browserbase_screenshot",
   description: `Capture a full-page screenshot and return it (and save as a resource).`,
   inputSchema: ScreenshotInputSchema,
+  annotations: {
+    title: "Take Screenshot",
+    readOnlyHint: true,
+  },
 };
 
 async function handleScreenshot(

--- a/src/tools/session.ts
+++ b/src/tools/session.ts
@@ -24,6 +24,10 @@ const createSessionSchema: ToolSchema<typeof CreateSessionInputSchema> = {
   description:
     "Create or reuse a Browserbase browser session and set it as active.",
   inputSchema: CreateSessionInputSchema,
+  annotations: {
+    title: "Create Session",
+    destructiveHint: true,
+  },
 };
 
 // Handle function for CreateSession using SessionManager
@@ -139,6 +143,10 @@ const closeSessionSchema: ToolSchema<typeof CloseSessionInputSchema> = {
   description:
     "Close the current Browserbase session and reset the active context.",
   inputSchema: CloseSessionInputSchema,
+  annotations: {
+    title: "Close Session",
+    destructiveHint: true,
+  },
 };
 
 async function handleCloseSession(context: Context): Promise<ToolResult> {

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,6 +1,7 @@
 import type {
   ImageContent,
   TextContent,
+  ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { z } from "zod";
 import type { Context } from "../context.js";
@@ -9,6 +10,7 @@ export type ToolSchema<Input extends InputType> = {
   name: string;
   description: string;
   inputSchema: Input;
+  annotations?: ToolAnnotations;
 };
 
 // Export InputType

--- a/src/tools/url.ts
+++ b/src/tools/url.ts
@@ -18,6 +18,10 @@ const getUrlSchema: ToolSchema<typeof GetUrlInputSchema> = {
   name: "browserbase_stagehand_get_url",
   description: "Return the current page URL (full URL with query/fragment).",
   inputSchema: GetUrlInputSchema,
+  annotations: {
+    title: "Get Current URL",
+    readOnlyHint: true,
+  },
 };
 
 async function handleGetUrl(


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all 9 tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

### Type Updates
- Added `ToolAnnotations` import from `@modelcontextprotocol/sdk/types.js`
- Extended `ToolSchema` type to include optional `annotations` field
- Updated `index.ts` to pass annotations when registering tools with the server

### Tools Annotated

**Destructive tools** (`destructiveHint: true`):
| Tool | Title | Reason |
|------|-------|--------|
| `browserbase_stagehand_navigate` | Navigate to URL | Changes page state |
| `browserbase_session_create` | Create Session | Creates browser resources |
| `browserbase_session_close` | Close Session | Destroys browser resources |
| `browserbase_stagehand_act` | Perform Action | Performs page interactions |
| `browserbase_stagehand_agent` | Execute Agent Task | Autonomous multi-step actions |

**Read-only tools** (`readOnlyHint: true`):
| Tool | Title | Reason |
|------|-------|--------|
| `browserbase_stagehand_extract` | Extract Data | Only reads page content |
| `browserbase_stagehand_observe` | Observe Elements | Only identifies elements |
| `browserbase_stagehand_get_url` | Get Current URL | Only reads current URL |
| `browserbase_screenshot` | Take Screenshot | Captures current state without modification |

## Why This Matters

- **Semantic metadata**: Annotations provide information beyond descriptions that helps LLMs understand tool behavior
- **Safer execution**: LLMs can distinguish read-only from destructive operations, enabling smarter tool selection
- **Better decisions**: LLMs can prioritize read-only tools for information gathering before taking destructive actions
- **Human-readable titles**: The `title` annotation provides cleaner names for tool display

## Testing

- [x] Code follows MCP SDK annotation patterns
- [x] All 9 tools have appropriate annotations
- [x] Annotations correctly categorize read-only vs destructive behavior
- [ ] CI will verify TypeScript compilation

## Before/After Example

**Before:**
```typescript
const extractSchema = {
  name: "browserbase_stagehand_extract",
  description: "Extract structured data...",
  inputSchema: ExtractInputSchema,
};
```

**After:**
```typescript
const extractSchema = {
  name: "browserbase_stagehand_extract",
  description: "Extract structured data...",
  inputSchema: ExtractInputSchema,
  annotations: {
    title: "Extract Data",
    readOnlyHint: true,
  },
};
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)