### PR TITLE
chore: support custom model provider baseURL  

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Required
+BROWSERBASE_API_KEY=your_browserbase_api_key
+BROWSERBASE_PROJECT_ID=your_browserbase_project_id
+
+
+MODEL_NAME=gemini-2.0-flash
+MODEL_API_KEY=your_model_provider_api_key
+
+# Custom model endpoint (if not using a public model provider)
+MODEL_BASE_URL=https://your-endpoint.example.com/v1
+
+MCP_PORT=3000

--- a/README.md
+++ b/README.md
@@ -137,6 +137,56 @@ cd mcp-server-browserbase
 docker build -t mcp-browserbase .
 ```
 
+#### Option 3: Docker Compose (Simplest)
+
+Run the MCP server as an HTTP service (`/mcp`) with one command.
+
+```bash
+# Clone the Repo
+git clone https://github.com/browserbase/mcp-server-browserbase.git
+cd mcp-server-browserbase
+
+# Create your environment file
+cp .env.example .env
+
+# Edit .env and set:
+# - BROWSERBASE_API_KEY
+# - BROWSERBASE_PROJECT_ID
+# - MODEL_NAME / MODEL_API_KEY / MODEL_BASE_URL (optional)
+
+# Start the server
+docker compose up -d --build
+```
+
+The server will be available at:
+
+```text
+http://localhost:3000/mcp
+```
+
+Use this in MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "browserbase": {
+      "type": "http",
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}
+```
+
+Useful commands:
+
+```bash
+# Follow logs
+docker compose logs -f
+
+# Stop
+docker compose down
+```
+
 Then in your MCP Config JSON run the server. To run locally we can use STDIO or self-host SHTTP.
 
 ### STDIO:
@@ -211,6 +261,7 @@ The Browserbase MCP server accepts the following command-line flags:
 | `--browserHeight <height>` | Browser viewport height (default: 768)                                      |
 | `--modelName <model>`      | The model to use for Stagehand (default: gemini-2.0-flash)                  |
 | `--modelApiKey <key>`      | API key for the custom model provider (required when using custom models)   |
+| `--baseUrl <url>`          | Base URL for custom model provider API (OpenAI-compatible/proxy endpoints)  |
 | `--experimental`           | Enable experimental features (default: false)                               |
 
 These flags can be passed directly to the CLI or configured in your MCP configuration file.
@@ -402,6 +453,31 @@ Here's how to configure different models:
         "anthropic/claude-sonnet-4.5",
         "--modelApiKey",
         "your-anthropic-api-key"
+      ],
+      "env": {
+        "BROWSERBASE_API_KEY": "",
+        "BROWSERBASE_PROJECT_ID": ""
+      }
+    }
+  }
+}
+```
+
+If you are routing model traffic through a custom OpenAI-compatible endpoint, add `--baseUrl`:
+
+```json
+{
+  "mcpServers": {
+    "browserbase": {
+      "command": "npx",
+      "args": [
+        "@browserbasehq/mcp-server-browserbase",
+        "--modelName",
+        "openai/gpt-5",
+        "--modelApiKey",
+        "your-model-api-key",
+        "--baseUrl",
+        "https://your-endpoint.example.com/v1"
       ],
       "env": {
         "BROWSERBASE_API_KEY": "",

--- a/config.d.ts
+++ b/config.d.ts
@@ -104,4 +104,9 @@ export type Config = {
    * @default false
    */
   experimental?: boolean;
+  /**
+   * Base URL for the custom model provider API
+   * Useful for OpenAI-compatible gateways/proxies
+   */
+  baseURL?: string;
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  browserbase-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: mcp-browserbase:latest
+    container_name: browserbase-mcp
+    restart: unless-stopped
+    ports:
+      - "${MCP_PORT:-3000}:3000"
+    environment:
+      BROWSERBASE_API_KEY: ${BROWSERBASE_API_KEY}
+      BROWSERBASE_PROJECT_ID: ${BROWSERBASE_PROJECT_ID}
+      MODEL_NAME: ${MODEL_NAME:-gemini-2.0-flash}
+      MODEL_API_KEY: ${MODEL_API_KEY:-}
+      MODEL_BASE_URL: ${MODEL_BASE_URL:-}
+    command:
+      - cli.js
+      - --port
+      - "3000"
+      - --host
+      - 0.0.0.0
+      - --modelName
+      - ${MODEL_NAME:-gemini-2.0-flash}
+      - --modelApiKey
+      - ${MODEL_API_KEY:-}
+      - --baseUrl
+      - ${MODEL_BASE_URL:-}

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export type CLIOptions = {
   browserHeight?: number;
   modelName?: string;
   modelApiKey?: string;
+  baseUrl?: string;
   keepAlive?: boolean;
   experimental?: boolean;
 };
@@ -95,6 +96,7 @@ export async function configFromCLIOptions(
     advancedStealth: cliOptions.advancedStealth,
     modelName: cliOptions.modelName,
     modelApiKey: cliOptions.modelApiKey,
+    baseURL: cliOptions.baseUrl,
     keepAlive: cliOptions.keepAlive,
     experimental: cliOptions.experimental,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,12 @@ export const configSchema = z
       .describe(
         "API key for the custom model provider. Required when using a model other than the default gemini-2.0-flash",
       ),
+    baseURL: z
+      .string()
+      .optional()
+      .describe(
+        "Base URL for the custom model provider API (for OpenAI-compatible endpoints/proxies)",
+      ),
     experimental: z
       .boolean()
       .optional()

--- a/src/program.ts
+++ b/src/program.ts
@@ -60,6 +60,10 @@ program
     "--modelApiKey <key>",
     "API key for the custom model provider (required when using custom models)",
   )
+  .option(
+    "--baseUrl <url>",
+    "Base URL for the custom model provider API (for proxies/compatible endpoints)",
+  )
   .option("--keepAlive", "Enable Browserbase Keep Alive Session")
   .option("--experimental", "Enable experimental features")
   .action(async (options) => {

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -35,6 +35,7 @@ export const createStagehandInstance = async (
       ? {
           apiKey: modelApiKey,
           modelName: modelName,
+          baseURL: config.baseURL,
         }
       : modelName,
     ...(params.browserbaseSessionID && {


### PR DESCRIPTION
## Changes
- Added `baseURL` support across config, CLI, and schema validation.
- Added CLI flag: `--baseUrl`.
- Added env var support: `MODEL_BASE_URL`.
- Wired `baseURL` into Stagehand model initialization.
- Added `docker-compose.yml` for local MCP server deployment.
- Updated `.env.example` and `README.md` with setup and usage examples.
