### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,8 @@ _Note: The model must be supported in Stagehand. Check out the docs [here](https
 Licensed under the Apache 2.0 License.
 
 Copyright 2025 Browserbase, Inc.
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/browserbase-mcp-server-browserbase).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/browserbase-mcp-server-browserbase)