### PR TITLE
[STG-1726] feat: rename package to @browserbasehq/mcp

### DIFF
--- a/.changeset/rename-package.md
+++ b/.changeset/rename-package.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/mcp": major
+---
+
+Renamed package from @browserbasehq/mcp-server-browserbase to @browserbasehq/mcp

--- a/.changeset/rename-package.md
+++ b/.changeset/rename-package.md
@@ -1,5 +1,0 @@
----
-"@browserbasehq/mcp": patch
----
-
-Renamed package from @browserbasehq/mcp-server-browserbase to @browserbasehq/mcp

--- a/.changeset/rename-package.md
+++ b/.changeset/rename-package.md
@@ -1,5 +1,5 @@
 ---
-"@browserbasehq/mcp": major
+"@browserbasehq/mcp": patch
 ---
 
 Renamed package from @browserbasehq/mcp-server-browserbase to @browserbasehq/mcp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @browserbasehq/mcp-server-browserbase
+# @browserbasehq/mcp
 
 ## 3.0.0
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Go into your MCP Config JSON and add the Browserbase Server:
   "mcpServers": {
     "browserbase": {
       "command": "npx",
-      "args": ["@browserbasehq/mcp-server-browserbase"],
+      "args": ["@browserbasehq/mcp"],
       "env": {
         "BROWSERBASE_API_KEY": "",
         "BROWSERBASE_PROJECT_ID": "",
@@ -173,7 +173,7 @@ The Browserbase MCP server accepts the following command-line flags:
 
 These flags can be passed directly to the CLI or configured in your MCP configuration file.
 
-> **Note:** These flags can only be used with the self-hosted server (npx @browserbasehq/mcp-server-browserbase or Docker).
+> **Note:** These flags can only be used with the self-hosted server (npx @browserbasehq/mcp or Docker).
 
 ### Model Configuration
 
@@ -187,7 +187,7 @@ Stagehand defaults to using Google's Gemini 2.5 Flash Lite model, but you can co
     "browserbase": {
       "command": "npx",
       "args": [
-        "@browserbasehq/mcp-server-browserbase",
+        "@browserbasehq/mcp",
         "--modelName",
         "anthropic/claude-sonnet-4.5",
         "--modelApiKey",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -4,7 +4,7 @@
   "mcpServers": {
     "mcp-server-browserbase": {
       "command": "npx",
-      "args": ["@browserbasehq/mcp-server-browserbase"]
+      "args": ["@browserbasehq/mcp"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@browserbasehq/mcp-server-browserbase",
+  "name": "@browserbasehq/mcp",
   "version": "3.0.0",
   "description": "MCP server for AI web browser automation using Browserbase and Stagehand",
   "mcpName": "io.github.browserbase/mcp-server-browserbase",

--- a/server.json
+++ b/server.json
@@ -12,7 +12,7 @@
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
-      "identifier": "@browserbasehq/mcp-server-browserbase",
+      "identifier": "@browserbasehq/mcp",
       "version": "2.2.0",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- Renames the npm package from `@browserbasehq/mcp-server-browserbase` to `@browserbasehq/mcp`
- Updates all references across `package.json`, `README.md`, `CHANGELOG.md`, `server.json`, and `gemini-extension.json`
- Includes a major version changeset since this is a breaking change

## Post-merge: maintainer action required

1. **Deprecate the old package on npm:**
   ```bash
   npm deprecate @browserbasehq/mcp-server-browserbase "This package has moved to @browserbasehq/mcp"
   ```

2. **Set up trusted publishing on npmjs.com for `@browserbasehq/mcp`** so the release workflow can publish to the new package name.

## Linear

https://linear.app/browserbase/issue/STG-1726/rename-npm-package-to-browserbasehqmcp

## Test plan

- [ ] Verify `npx @browserbasehq/mcp` works after publishing
- [ ] Verify the old package shows the deprecation notice
- [ ] Verify trusted publishing is configured for the new package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)