### PR TITLE
[STG-1730] fix: add repository field for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "license": "Apache-2.0",
   "author": "Browserbase, Inc. (https://www.browserbase.com/)",
   "homepage": "https://www.browserbase.com",
-  "bugs": "https://github.com/modelcontextprotocol/servers/issues",
+  "bugs": "https://github.com/browserbase/mcp-server-browserbase/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/browserbase/mcp-server-browserbase"
+  },
   "type": "module",
   "main": "./cli.js",
   "module": "./src/index.ts",


### PR DESCRIPTION
## Summary
- Add `repository.url` to `package.json` — npm provenance validation requires this to match the GitHub repo
- Fix `bugs` URL to point to this repo instead of `modelcontextprotocol/servers`

This is the root cause of the E422 on publish:
```
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match
"https://github.com/browserbase/mcp-server-browserbase" from provenance
```

Linear: https://linear.app/browserbase/issue/STG-1730/stg-fix-release-workflow-for-trusted-publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)