### PR TITLE
feat: add MCP tool annotations (readOnlyHint, idempotentHint, destructiveHint)

### DIFF
--- a/src/tools/act.ts
+++ b/src/tools/act.ts
@@ -13,6 +13,9 @@ const actSchema: ToolSchema<typeof ActInputSchema> = {
   name: "act",
   description: "Perform an action on the page",
   inputSchema: ActInputSchema,
+  annotations: {
+    destructiveHint: false,
+  },
 };
 
 async function handleAct(

--- a/src/tools/extract.ts
+++ b/src/tools/extract.ts
@@ -13,6 +13,9 @@ const extractSchema: ToolSchema<typeof ExtractInputSchema> = {
   name: "extract",
   description: "Extract data from the page",
   inputSchema: ExtractInputSchema,
+  annotations: {
+    readOnlyHint: true,
+  },
 };
 
 async function handleExtract(

--- a/src/tools/navigate.ts
+++ b/src/tools/navigate.ts
@@ -13,6 +13,9 @@ const navigateSchema: ToolSchema<typeof NavigateInputSchema> = {
   name: "navigate",
   description: "Navigate to a URL",
   inputSchema: NavigateInputSchema,
+  annotations: {
+    idempotentHint: true,
+  },
 };
 
 async function handleNavigate(

--- a/src/tools/observe.ts
+++ b/src/tools/observe.ts
@@ -13,6 +13,9 @@ const observeSchema: ToolSchema<typeof ObserveInputSchema> = {
   name: "observe",
   description: "Observe actionable elements on the page",
   inputSchema: ObserveInputSchema,
+  annotations: {
+    readOnlyHint: true,
+  },
 };
 
 async function handleObserve(

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -5,10 +5,17 @@ import type {
 import type { z } from "zod";
 import type { Context } from "../context.js";
 
+export type ToolAnnotations = {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+};
+
 export type ToolSchema<Input extends InputType> = {
   name: string;
   description: string;
   inputSchema: Input;
+  annotations?: ToolAnnotations;
 };
 
 // Export InputType


### PR DESCRIPTION
## Summary
- Add MCP tool annotations to Stagehand tool definitions: readOnlyHint for observe/extract, idempotentHint for navigate, destructiveHint for act

## Why
Issue #157: Stagehand tool definitions are missing MCP annotations (readOnlyHint, idempotentHint, destructiveHint) which are optional hints defined in the MCP spec.

## Validation
- [x] Code review passed
- [x] Branch pushed to fork