### PR TITLE
[CE-955] Rename advancedStealth to verified

### DIFF
--- a/.changeset/rename-advanced-stealth-to-verified.md
+++ b/.changeset/rename-advanced-stealth-to-verified.md
@@ -1,0 +1,14 @@
+---
+"@browserbasehq/mcp": major
+---
+
+Rename `advancedStealth` to `verified` to match the renamed Browserbase API field.
+
+**Breaking changes:**
+
+- CLI flag `--advancedStealth` renamed to `--verified`
+- Config field `advancedStealth` renamed to `verified` (in `config.d.ts` / Smithery `configSchema`)
+
+Migration: replace `--advancedStealth` with `--verified` in your CLI invocations, and rename the `advancedStealth` field to `verified` in any config files or `configSchema` overrides.
+
+Also bumps the minimum `@browserbasehq/stagehand` peer to `^3.3.0`, the version that introduced support for the `verified` browser setting.

--- a/.changeset/rename-advanced-stealth-to-verified.md
+++ b/.changeset/rename-advanced-stealth-to-verified.md
@@ -1,14 +1,14 @@
 ---
-"@browserbasehq/mcp": major
+"@browserbasehq/mcp": minor
 ---
 
-Rename `advancedStealth` to `verified` to match the renamed Browserbase API field.
+Add `verified` as the canonical Browserbase Verified Identity setting while preserving `advancedStealth` as a deprecated alias.
 
-**Breaking changes:**
+**Changes:**
 
-- CLI flag `--advancedStealth` renamed to `--verified`
-- Config field `advancedStealth` renamed to `verified` (in `config.d.ts` / Smithery `configSchema`)
+- CLI flag `--verified` added; `--advancedStealth` remains supported as a deprecated alias
+- Config field `verified` added; `advancedStealth` remains supported as a deprecated alias in `config.d.ts` and Smithery `configSchema`
 
-Migration: replace `--advancedStealth` with `--verified` in your CLI invocations, and rename the `advancedStealth` field to `verified` in any config files or `configSchema` overrides.
+Migration: prefer `--verified` in CLI invocations and `verified` in config files or `configSchema` overrides.
 
 Also bumps the minimum `@browserbasehq/stagehand` peer to `^3.3.0`, the version that introduced support for the Verified Identity setting.

--- a/.changeset/rename-advanced-stealth-to-verified.md
+++ b/.changeset/rename-advanced-stealth-to-verified.md
@@ -11,4 +11,4 @@ Rename `advancedStealth` to `verified` to match the renamed Browserbase API fiel
 
 Migration: replace `--advancedStealth` with `--verified` in your CLI invocations, and rename the `advancedStealth` field to `verified` in any config files or `configSchema` overrides.
 
-Also bumps the minimum `@browserbasehq/stagehand` peer to `^3.3.0`, the version that introduced support for the `verified` browser setting.
+Also bumps the minimum `@browserbasehq/stagehand` peer to `^3.3.0`, the version that introduced support for the Verified Identity setting.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The Browserbase MCP server accepts the following command-line flags:
 | Flag                       | Description                                                                 |
 | -------------------------- | --------------------------------------------------------------------------- |
 | `--proxies`                | Enable Browserbase proxies for the session                                  |
-| `--advancedStealth`        | Enable Browserbase Advanced Stealth (Only for Scale Plan Users)             |
+| `--verified`               | Enable Browserbase Verified Browser Mode (Only for Scale Plan Users)        |
 | `--keepAlive`              | Enable Browserbase Keep Alive Session                                       |
 | `--contextId <contextId>`  | Specify a Browserbase Context ID to use                                     |
 | `--persist`                | Whether to persist the Browserbase context (default: true)                  |

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The Browserbase MCP server accepts the following command-line flags:
 | Flag                       | Description                                                                 |
 | -------------------------- | --------------------------------------------------------------------------- |
 | `--proxies`                | Enable Browserbase proxies for the session                                  |
-| `--verified`               | Enable Browserbase Verified Browser Mode (Only for Scale Plan Users)        |
+| `--verified`               | Enable Browserbase Verified Identity (Only for Scale Plan Users)            |
 | `--keepAlive`              | Enable Browserbase Keep Alive Session                                       |
 | `--contextId <contextId>`  | Specify a Browserbase Context ID to use                                     |
 | `--persist`                | Whether to persist the Browserbase context (default: true)                  |

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The Browserbase MCP server accepts the following command-line flags:
 | -------------------------- | --------------------------------------------------------------------------- |
 | `--proxies`                | Enable Browserbase proxies for the session                                  |
 | `--verified`               | Enable Browserbase Verified Identity (Only for Scale Plan Users)            |
+| `--advancedStealth`        | Deprecated alias for `--verified`                                           |
 | `--keepAlive`              | Enable Browserbase Keep Alive Session                                       |
 | `--contextId <contextId>`  | Specify a Browserbase Context ID to use                                     |
 | `--persist`                | Whether to persist the Browserbase context (default: true)                  |

--- a/config.d.ts
+++ b/config.d.ts
@@ -17,11 +17,11 @@ export type Config = {
    */
   proxies?: boolean;
   /**
-   * Use advanced stealth mode. Only available to Browserbase Scale Plan users.
+   * Use Verified Browser Mode (formerly Advanced Stealth). Only available to Browserbase Scale Plan users.
    *
    * @default false
    */
-  advancedStealth?: boolean;
+  verified?: boolean;
   /**
    * Whether or not to keep the Browserbase session alive
    *

--- a/config.d.ts
+++ b/config.d.ts
@@ -17,7 +17,7 @@ export type Config = {
    */
   proxies?: boolean;
   /**
-   * Use Verified Browser Mode (formerly Advanced Stealth). Only available to Browserbase Scale Plan users.
+   * Use Browserbase Verified Identity (formerly Advanced Stealth). Only available to Browserbase Scale Plan users.
    *
    * @default false
    */

--- a/config.d.ts
+++ b/config.d.ts
@@ -17,7 +17,7 @@ export type Config = {
    */
   proxies?: boolean;
   /**
-   * Use Browserbase Verified Identity (formerly Advanced Stealth). Only available to Browserbase Scale Plan users.
+   * Use Browserbase Verified Identity. Only available to Browserbase Scale Plan users.
    *
    * @default false
    */

--- a/config.d.ts
+++ b/config.d.ts
@@ -23,6 +23,12 @@ export type Config = {
    */
   verified?: boolean;
   /**
+   * Deprecated alias for verified.
+   *
+   * @default false
+   */
+  advancedStealth?: boolean;
+  /**
    * Whether or not to keep the Browserbase session alive
    *
    * @default false

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.6.0",
-    "@browserbasehq/stagehand": "^3.0.8",
+    "@browserbasehq/stagehand": "^3.3.0",
     "@modelcontextprotocol/sdk": "^1.13.1",
     "commander": "^14.0.0",
     "dotenv": "^16.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.6.0
         version: 2.6.0
       '@browserbasehq/stagehand':
-        specifier: ^3.0.8
-        version: 3.0.8(@opentelemetry/api@1.9.0)(deepmerge@4.3.1)(dotenv@16.6.1)(zod@3.25.76)
+        specifier: ^3.3.0
+        version: 3.3.0(@opentelemetry/api@1.9.0)(deepmerge@4.3.1)(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.13.1
         version: 1.15.1
@@ -78,20 +78,26 @@ importers:
 
 packages:
 
+  '@ai-sdk/amazon-bedrock@3.0.99':
+    resolution: {integrity: sha512-d/WsYOlqjQeEwTewawjrlhoWfHt3q1vRT5/XdFJ6U+KYd/3HnAlrA3rg0+T7xMk98XmctaILJb45Ct/8zrGxSA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/anthropic@1.2.12':
     resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
 
-  '@ai-sdk/anthropic@2.0.40':
-    resolution: {integrity: sha512-aHtqlIIS8lyesSNFxevLGWozCCZ1xQ4Wy2HfQSVVQu3dWtndfPzF6hbWof2Way+qNrvRtjnBpRQyaVeu6Js4pQ==}
+  '@ai-sdk/anthropic@2.0.57':
+    resolution: {integrity: sha512-DREpYqW2pylgaj69gZ+K8u92bo9DaMgFdictYnY+IwYeY3bawQ4zI7l/o1VkDsBDljAx8iYz5lPURwVZNu+Xpg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/anthropic@2.0.57':
-    resolution: {integrity: sha512-DREpYqW2pylgaj69gZ+K8u92bo9DaMgFdictYnY+IwYeY3bawQ4zI7l/o1VkDsBDljAx8iYz5lPURwVZNu+Xpg==}
+  '@ai-sdk/anthropic@2.0.79':
+    resolution: {integrity: sha512-K0U09FPDO1kmLPjRLXFcNSvmnKHJBMARCb8r3Ulw7wU6/+Zh9djWcFDiPPNsklg6yAezcdLTcYPszgWJJ6iOTA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -114,8 +120,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@2.0.5':
-    resolution: {integrity: sha512-5TTDSl0USWY6YGnb4QmJGplFZhk+p9OT7hZevAaER6OGiZ17LB1GypsGYDpNo/MiVMklk8kX4gk6p1/R/EiJ8Q==}
+  '@ai-sdk/gateway@2.0.86':
+    resolution: {integrity: sha512-pP9F5G7C5sqZtAwquFB+g50lVS/s4Wf/ll2WSm0ODk0Iix27trVgBDpFK5CBletcQXSDlAvSQQi25nBodYLt3g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -126,14 +132,14 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@2.0.26':
-    resolution: {integrity: sha512-LMCT8TDwj1ww4W34f1YJHfk2LggsMV4dqF8qSolJIopdERCclA+S+LzaIaiyeoYDD+slUrf3FXvi1t+yd21jxQ==}
+  '@ai-sdk/google@2.0.52':
+    resolution: {integrity: sha512-2XUnGi3f7TV4ujoAhA+Fg3idUoG/+Y2xjCRg70a1/m0DH1KSQqYaCboJ1C19y6ZHGdf5KNT20eJdswP6TvrY2g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@2.0.52':
-    resolution: {integrity: sha512-2XUnGi3f7TV4ujoAhA+Fg3idUoG/+Y2xjCRg70a1/m0DH1KSQqYaCboJ1C19y6ZHGdf5KNT20eJdswP6TvrY2g==}
+  '@ai-sdk/google@2.0.72':
+    resolution: {integrity: sha512-BjDY6l+rV4CmHKjZe4H0uRXW3M2o+g7PaYM8oFpW+9PP1qKNEybnJ6//Si7BSf6DT+86dKARrtEl09lxSSaMaA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -192,6 +198,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@3.0.25':
+    resolution: {integrity: sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@1.1.3':
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
@@ -202,6 +214,10 @@ packages:
 
   '@ai-sdk/provider@2.0.1':
     resolution: {integrity: sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@1.2.12':
@@ -235,18 +251,32 @@ packages:
   '@anthropic-ai/sdk@0.39.0':
     resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
 
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
   '@babel/runtime@7.28.3':
     resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
     engines: {node: '>=6.9.0'}
 
+  '@browserbasehq/sdk@2.10.0':
+    resolution: {integrity: sha512-pOL4yW8P8AI2+N5y6zEP6XXKqIXtYyKunr1JXppqQDOyKLxxvZEDqQCHJXWUzqgx3R1tGWpn7m9AjXN7MeYInA==}
+
   '@browserbasehq/sdk@2.6.0':
     resolution: {integrity: sha512-83iXP5D7xMm8Wyn66TUaUrgoByCmAJuoMoZQI3sGg3JAiMlTfnCIMqyVBoNSaItaPIkaCnrsj6LiusmXV2X9YA==}
 
-  '@browserbasehq/stagehand@3.0.8':
-    resolution: {integrity: sha512-ppI4PmqjRnFEpTtaQyRzKZgL4uVzscOQsDjBpQlvZNhhEp3da1wBaP1ml/hMfsuAmY9wOUwdN4V0uyyRbxWAdA==}
+  '@browserbasehq/stagehand@3.3.0':
+    resolution: {integrity: sha512-eIYsId85c0pPXBAuqHdI3arBB1ecJn9E3eTzVaa968U+beoxOtqOJmx65K4xcZQSfd9BonQeIBsE7ujrHaq9VQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       deepmerge: ^4.3.1
-      dotenv: ^16.4.5
       zod: ^3.25.76 || ^4.2.0
 
   '@cfworker/json-schema@4.1.1':
@@ -560,8 +590,8 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@langchain/core@0.3.79':
-    resolution: {integrity: sha512-ZLAs5YMM5N2UXN3kExMglltJrKKoW7hs3KMZFlXUnD7a5DFKBYxPFMeXA4rT+uvTxuJRZPCYX0JKI5BhyAWx4A==}
+  '@langchain/core@0.3.80':
+    resolution: {integrity: sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==}
     engines: {node: '>=18'}
 
   '@langchain/openai@0.4.9':
@@ -707,8 +737,41 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.12':
     resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
 
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+  '@smithy/eventstream-codec@4.2.14':
+    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -814,8 +877,8 @@ packages:
     resolution: {integrity: sha512-YzfhzcTnZVPiLfP/oeKtDp2evwvHLMe0LOy7oe+hb9KKIumLNohYS9Hgp1ifwpu42YWxhZE8yieggz6JpqO/1w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vercel/oidc@3.0.3':
-    resolution: {integrity: sha512-yNEQvPcVrK9sIe637+I0jD6leluPxzwJKx/Haw6F4H77CdDsszUn5V3o96LPziXkSNE2B83+Z3mjqGKBK/R6Gg==}
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
   '@vitest/expect@4.1.2':
@@ -883,8 +946,8 @@ packages:
       react:
         optional: true
 
-  ai@5.0.86:
-    resolution: {integrity: sha512-ooHwNTkLdedFf98iQhtSc5btc/P4UuXuOpYneoifq0190vqosLunNdW8Hs6CiE0Am7YOGNplDK56JIPlHZIL4w==}
+  ai@5.0.183:
+    resolution: {integrity: sha512-lmLFkxJ2epeUXi6QXi/9VYs1HF61vikpP8vGnGd3Erdh/syUyfZ/DC1to2AoNwytBNpICN3OGbTpwc7jfPewgg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -981,6 +1044,9 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  aws4fetch@1.0.20:
+    resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
+
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
     peerDependencies:
@@ -1036,6 +1102,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -1692,11 +1759,12 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -2303,6 +2371,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -3099,6 +3168,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -3107,6 +3177,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -3304,23 +3375,34 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/amazon-bedrock@3.0.99(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/anthropic': 2.0.79(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(zod@3.25.76)
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/util-utf8': 4.2.2
+      aws4fetch: 1.0.20
+      zod: 3.25.76
+    optional: true
+
   '@ai-sdk/anthropic@1.2.12(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/anthropic@2.0.40(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.15(zod@3.25.76)
-      zod: 3.25.76
-    optional: true
-
   '@ai-sdk/anthropic@2.0.57(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      zod: 3.25.76
+    optional: true
+
+  '@ai-sdk/anthropic@2.0.79(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
@@ -3348,11 +3430,11 @@ snapshots:
       zod: 3.25.76
     optional: true
 
-  '@ai-sdk/gateway@2.0.5(zod@3.25.76)':
+  '@ai-sdk/gateway@2.0.86(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.15(zod@3.25.76)
-      '@vercel/oidc': 3.0.3
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
   '@ai-sdk/google-vertex@3.0.97(zod@3.25.76)':
@@ -3367,17 +3449,17 @@ snapshots:
       - supports-color
     optional: true
 
-  '@ai-sdk/google@2.0.26(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.15(zod@3.25.76)
-      zod: 3.25.76
-    optional: true
-
   '@ai-sdk/google@2.0.52(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      zod: 3.25.76
+    optional: true
+
+  '@ai-sdk/google@2.0.72(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
@@ -3432,17 +3514,25 @@ snapshots:
   '@ai-sdk/provider-utils@3.0.15(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
+    optional: true
 
   '@ai-sdk/provider-utils@3.0.20(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
     optional: true
+
+  '@ai-sdk/provider-utils@3.0.25(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -3451,11 +3541,15 @@ snapshots:
   '@ai-sdk/provider@2.0.0':
     dependencies:
       json-schema: 0.4.0
+    optional: true
 
   '@ai-sdk/provider@2.0.1':
     dependencies:
       json-schema: 0.4.0
-    optional: true
+
+  '@ai-sdk/provider@2.0.3':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/react@1.2.12(react@19.1.0)(zod@3.25.76)':
     dependencies:
@@ -3480,7 +3574,7 @@ snapshots:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
 
   '@ai-sdk/xai@2.0.30(zod@3.25.76)':
     dependencies:
@@ -3502,7 +3596,39 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    optional: true
+
   '@babel/runtime@7.28.3': {}
+
+  '@browserbasehq/sdk@2.10.0':
+    dependencies:
+      '@types/node': 18.19.119
+      '@types/node-fetch': 2.6.12
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@browserbasehq/sdk@2.6.0':
     dependencies:
@@ -3516,18 +3642,17 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@browserbasehq/stagehand@3.0.8(@opentelemetry/api@1.9.0)(deepmerge@4.3.1)(dotenv@16.6.1)(zod@3.25.76)':
+  '@browserbasehq/stagehand@3.3.0(@opentelemetry/api@1.9.0)(deepmerge@4.3.1)(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider': 2.0.1
       '@anthropic-ai/sdk': 0.39.0
-      '@browserbasehq/sdk': 2.6.0
+      '@browserbasehq/sdk': 2.10.0
       '@google/genai': 1.24.0(@modelcontextprotocol/sdk@1.17.5)(bufferutil@4.0.9)
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.79(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76)))(ws@8.18.3(bufferutil@4.0.9))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76)))(ws@8.18.3(bufferutil@4.0.9))
       '@modelcontextprotocol/sdk': 1.17.5
-      ai: 5.0.86(zod@3.25.76)
+      ai: 5.0.183(zod@3.25.76)
       deepmerge: 4.3.1
       devtools-protocol: 0.0.1464554
-      dotenv: 16.6.1
       fetch-cookie: 3.1.0
       openai: 4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76)
       pino: 9.7.0
@@ -3537,11 +3662,12 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     optionalDependencies:
-      '@ai-sdk/anthropic': 2.0.40(zod@3.25.76)
+      '@ai-sdk/amazon-bedrock': 3.0.99(zod@3.25.76)
+      '@ai-sdk/anthropic': 2.0.57(zod@3.25.76)
       '@ai-sdk/azure': 2.0.60(zod@3.25.76)
       '@ai-sdk/cerebras': 1.0.28(zod@3.25.76)
       '@ai-sdk/deepseek': 1.0.26(zod@3.25.76)
-      '@ai-sdk/google': 2.0.26(zod@3.25.76)
+      '@ai-sdk/google': 2.0.72(zod@3.25.76)
       '@ai-sdk/google-vertex': 3.0.97(zod@3.25.76)
       '@ai-sdk/groq': 2.0.27(zod@3.25.76)
       '@ai-sdk/mistral': 2.0.22(zod@3.25.76)
@@ -3549,7 +3675,7 @@ snapshots:
       '@ai-sdk/perplexity': 2.0.16(zod@3.25.76)
       '@ai-sdk/togetherai': 1.0.26(zod@3.25.76)
       '@ai-sdk/xai': 2.0.30(zod@3.25.76)
-      '@langchain/core': 0.3.79(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76))
       bufferutil: 4.0.9
       chrome-launcher: 1.2.1
       ollama-ai-provider-v2: 1.5.2(zod@3.25.76)
@@ -3900,7 +4026,7 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@langchain/core@0.3.79(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76))':
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
@@ -3920,9 +4046,9 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.79(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76)))(ws@8.18.3(bufferutil@4.0.9))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76)))(ws@8.18.3(bufferutil@4.0.9))':
     dependencies:
-      '@langchain/core': 0.3.79(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76))
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76))
       js-tiktoken: 1.0.21
       openai: 4.104.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76)
       zod: 3.25.76
@@ -4073,7 +4199,57 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.12': {}
 
-  '@standard-schema/spec@1.0.0': {}
+  '@smithy/eventstream-codec@4.2.14':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+    optional: true
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4215,7 +4391,7 @@ snapshots:
       '@typescript-eslint/types': 8.37.0
       eslint-visitor-keys: 4.2.1
 
-  '@vercel/oidc@3.0.3': {}
+  '@vercel/oidc@3.1.0': {}
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -4291,11 +4467,11 @@ snapshots:
     optionalDependencies:
       react: 19.1.0
 
-  ai@5.0.86(zod@3.25.76):
+  ai@5.0.183(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 2.0.5(zod@3.25.76)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.15(zod@3.25.76)
+      '@ai-sdk/gateway': 2.0.86(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
@@ -4405,6 +4581,9 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  aws4fetch@1.0.20:
+    optional: true
 
   b4a@1.7.3:
     optional: true
@@ -5991,8 +6170,8 @@ snapshots:
 
   ollama-ai-provider-v2@1.5.2(zod@3.25.76):
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.15(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
       zod: 3.25.76
     optional: true
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { configFromCLIOptions, normalizeVerifiedConfig } from "./config.js";
+import { configSchema } from "./index.js";
+
+describe("verified config compatibility", () => {
+  it("maps the legacy CLI advancedStealth alias to verified", async () => {
+    const config = await configFromCLIOptions({ advancedStealth: true });
+
+    expect(config.verified).toBe(true);
+  });
+
+  it("prefers verified when both verified and advancedStealth are set", () => {
+    const config = normalizeVerifiedConfig({
+      browserbaseApiKey: "test-key",
+      browserbaseProjectId: "test-project",
+      verified: false,
+      advancedStealth: true,
+    });
+
+    expect(config.verified).toBe(false);
+  });
+
+  it("accepts advancedStealth in the Smithery config schema", () => {
+    const config = configSchema.parse({
+      browserbaseApiKey: "test-key",
+      browserbaseProjectId: "test-project",
+      advancedStealth: true,
+    });
+
+    expect(config.advancedStealth).toBe(true);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ export type ToolCapability = "core" | string;
 // Define Command Line Options Structure
 export type CLIOptions = {
   proxies?: boolean;
-  advancedStealth?: boolean;
+  verified?: boolean;
   contextId?: string;
   persist?: boolean;
   port?: number;
@@ -92,7 +92,7 @@ export async function configFromCLIOptions(
       browserWidth: cliOptions.browserWidth,
       browserHeight: cliOptions.browserHeight,
     },
-    advancedStealth: cliOptions.advancedStealth,
+    verified: cliOptions.verified,
     modelName: cliOptions.modelName,
     modelApiKey: cliOptions.modelApiKey,
     keepAlive: cliOptions.keepAlive,

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export type ToolCapability = "core" | string;
 export type CLIOptions = {
   proxies?: boolean;
   verified?: boolean;
+  advancedStealth?: boolean;
   contextId?: string;
   persist?: boolean;
   port?: number;
@@ -38,7 +39,9 @@ const defaultConfig: Config = {
 export async function resolveConfig(cliOptions: CLIOptions): Promise<Config> {
   const cliConfig = await configFromCLIOptions(cliOptions);
   // Order: Defaults < File Config < CLI Overrides
-  const mergedConfig = mergeConfig(defaultConfig, cliConfig);
+  const mergedConfig = normalizeVerifiedConfig(
+    mergeConfig(defaultConfig, cliConfig),
+  );
 
   // --- Add Browserbase Env Vars ---
   if (!mergedConfig.modelApiKey) {
@@ -92,11 +95,21 @@ export async function configFromCLIOptions(
       browserWidth: cliOptions.browserWidth,
       browserHeight: cliOptions.browserHeight,
     },
-    verified: cliOptions.verified,
+    verified: cliOptions.verified ?? cliOptions.advancedStealth,
     modelName: cliOptions.modelName,
     modelApiKey: cliOptions.modelApiKey,
     keepAlive: cliOptions.keepAlive,
     experimental: cliOptions.experimental,
+  };
+}
+
+export function normalizeVerifiedConfig(config: Config): Config {
+  const verified = config.verified ?? config.advancedStealth;
+  if (verified === undefined) return config;
+
+  return {
+    ...config,
+    verified,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,11 +29,11 @@ export const configSchema = z
       .boolean()
       .optional()
       .describe("Whether or not to use Browserbase proxies"),
-    advancedStealth: z
+    verified: z
       .boolean()
       .optional()
       .describe(
-        "Use advanced stealth mode. Only available to Browserbase Scale Plan users",
+        "Use Verified Browser Mode (formerly Advanced Stealth). Only available to Browserbase Scale Plan users",
       ),
     keepAlive: z
       .boolean()

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export const configSchema = z
       .boolean()
       .optional()
       .describe(
-        "Use Verified Browser Mode (formerly Advanced Stealth). Only available to Browserbase Scale Plan users",
+        "Use Browserbase Verified Identity (formerly Advanced Stealth). Only available to Browserbase Scale Plan users",
       ),
     keepAlive: z
       .boolean()

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export const configSchema = z
       .boolean()
       .optional()
       .describe(
-        "Use Browserbase Verified Identity (formerly Advanced Stealth). Only available to Browserbase Scale Plan users",
+        "Use Browserbase Verified Identity. Only available to Browserbase Scale Plan users",
       ),
     advancedStealth: z
       .boolean()

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import type { MCPToolsArray } from "./types/types.js";
 
 import { Context } from "./context.js";
 import type { Config } from "../config.d.ts";
+import { normalizeVerifiedConfig } from "./config.js";
 import { TOOLS } from "./tools/index.js";
 import { RESOURCE_TEMPLATES } from "./mcp/resources.js";
 
@@ -35,6 +36,10 @@ export const configSchema = z
       .describe(
         "Use Browserbase Verified Identity (formerly Advanced Stealth). Only available to Browserbase Scale Plan users",
       ),
+    advancedStealth: z
+      .boolean()
+      .optional()
+      .describe("Deprecated alias for verified"),
     keepAlive: z
       .boolean()
       .optional()
@@ -135,7 +140,7 @@ export default function ({ config }: { config: z.infer<typeof configSchema> }) {
     },
   });
 
-  const internalConfig: Config = config as Config;
+  const internalConfig: Config = normalizeVerifiedConfig(config as Config);
 
   // Create the context, passing server instance and config
   const contextId = randomUUID();

--- a/src/program.ts
+++ b/src/program.ts
@@ -36,8 +36,8 @@ program
   .option("--browserbaseProjectId <id>", "The Browserbase Project ID to use")
   .option("--proxies", "Use Browserbase proxies.")
   .option(
-    "--advancedStealth",
-    "Use advanced stealth mode. Only available to Browserbase Scale Plan users.",
+    "--verified",
+    "Use Verified Browser Mode (formerly Advanced Stealth). Only available to Browserbase Scale Plan users.",
   )
   .option("--contextId <contextId>", "Browserbase Context ID to use.")
   .option(

--- a/src/program.ts
+++ b/src/program.ts
@@ -39,6 +39,7 @@ program
     "--verified",
     "Use Browserbase Verified Identity (formerly Advanced Stealth). Only available to Browserbase Scale Plan users.",
   )
+  .option("--advancedStealth", "Deprecated alias for --verified.")
   .option("--contextId <contextId>", "Browserbase Context ID to use.")
   .option(
     "--persist [boolean]",

--- a/src/program.ts
+++ b/src/program.ts
@@ -37,7 +37,7 @@ program
   .option("--proxies", "Use Browserbase proxies.")
   .option(
     "--verified",
-    "Use Browserbase Verified Identity (formerly Advanced Stealth). Only available to Browserbase Scale Plan users.",
+    "Use Browserbase Verified Identity. Only available to Browserbase Scale Plan users.",
   )
   .option("--advancedStealth", "Deprecated alias for --verified.")
   .option("--contextId <contextId>", "Browserbase Context ID to use.")

--- a/src/program.ts
+++ b/src/program.ts
@@ -37,7 +37,7 @@ program
   .option("--proxies", "Use Browserbase proxies.")
   .option(
     "--verified",
-    "Use Verified Browser Mode (formerly Advanced Stealth). Only available to Browserbase Scale Plan users.",
+    "Use Browserbase Verified Identity (formerly Advanced Stealth). Only available to Browserbase Scale Plan users.",
   )
   .option("--contextId <contextId>", "Browserbase Context ID to use.")
   .option(

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -56,7 +56,7 @@ export const createStagehandInstance = async (
               persist: config.context?.persist ?? true,
             }
           : undefined,
-        advancedStealth: config.advancedStealth ?? undefined,
+        verified: config.verified ?? undefined,
       },
       userMetadata: {
         mcp: "true",

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -56,7 +56,7 @@ export const createStagehandInstance = async (
               persist: config.context?.persist ?? true,
             }
           : undefined,
-        verified: config.verified ?? undefined,
+        verified: config.verified ?? config.advancedStealth ?? undefined,
       },
       userMetadata: {
         mcp: "true",


### PR DESCRIPTION
## Summary

The Browserbase API renamed the `advancedStealth` browser setting to `verified`. The MCP server still passes `advancedStealth` through Stagehand's `browserbaseSessionCreateParams.browserSettings`, which is the legacy alias — when customers configure the new `--verified` flag they expect, it isn't recognized by this server.

Reported by Drata: `sessionManager.js passes advancedStealth: true but the Browserbase API needs verified: true`.

## Changes

- `config.d.ts` — `advancedStealth` → `verified` on the public `Config` type
- `src/config.ts` — `CLIOptions.advancedStealth` → `CLIOptions.verified`, forwarded as `verified`
- `src/program.ts` — commander flag `--advancedStealth` → `--verified`
- `src/index.ts` — Smithery-facing `configSchema` field renamed
- `src/sessionManager.ts` — forwards as `browserSettings.verified` to Stagehand
- `README.md` — flag table updated
- `package.json` — bump `@browserbasehq/stagehand` to `^3.3.0` (the version that introduced `verified` support — see https://github.com/browserbase/stagehand/pull/1980)
- Added a `major` changeset documenting the breaking rename

## Breaking change

Existing configs that pass `--advancedStealth` or `{ advancedStealth: true }` will need to be updated to `--verified` / `{ verified: true }`. Documented in the changeset.

## Test plan

- TypeScript compile (`pnpm build`) — verified locally that the rename resolves cleanly through to Stagehand's `BrowserbaseBrowserSettingsSchema.verified`
- Manual smoke: `mcp-server-browserbase --verified` should now propagate `verified: true` to the Browserbase Sessions API

Linear: https://linear.app/browserbase/issue/CE-955/rename-advancedstealth-to-verified-in-mcp-server